### PR TITLE
Delete INSTALL-MC.md

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -87,7 +87,6 @@ module.exports = {
 					    'INSTALL', // Installing PojavLauncher
                         'BUILD-FROM-SOURCE', // Building PojavLauncher from source
 						'SIGN-IN', // Signing in
-						'INSTALL-MC', // Downloading Minecraft
 						'DEFAULT-CONTROLS', // Taking a look at the controls
 					]
 				},

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -87,6 +87,7 @@ module.exports = {
 					    'INSTALL', // Installing PojavLauncher
                         'BUILD-FROM-SOURCE', // Building PojavLauncher from source
 						'SIGN-IN', // Signing in
+						'INSTALL-MC', // Downloading Minecraft
 						'DEFAULT-CONTROLS', // Taking a look at the controls
 					]
 				},

--- a/INSTALL-MC.md
+++ b/INSTALL-MC.md
@@ -1,1 +1,0 @@
-# Downloading a copy of Minecraft


### PR DESCRIPTION
"Downloading a copy of Minecraft" is handled by the launcher automatically now, we don't need a guide for this anymore