### PR TITLE
Make actions actually do something useful again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build/Test/Deploy
+name: Build
 on:
   push:
     branches-ignore:
@@ -7,26 +7,23 @@ on:
   pull_request:
 jobs:
   build:
-    name: Build and Deploy
+    name: Build and Upload
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v2-beta
-        with:
-          node-version: '12'
       - name: Checkout Repository
         uses: actions/checkout@v2
         with:
           fetch-depth: '0'
           persist-credentials: false
           submodules: 'recursive'
-      - name: Install
-        run: npm install
-      - name: Build
-        run: npm run build
-      - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4.1.5
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main'}}
+      - name: Setup Node
+        uses: actions/setup-node@v2-beta
         with:
-          BRANCH: gh-pages
-          FOLDER: docs
-          CLEAN: true
+          node-version: '12'
+      - name: Build
+        run: npm install && npm run build
+      - name: Upload Build
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Build and Deploy
+on:
+  workflow_dispatch:
+jobs:
+  build:
+    name: Build and Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+          persist-credentials: false
+          submodules: 'recursive'
+      - name: Build
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: '12'
+        run: npm install && npm run build
+  deploy:
+    environment:
+      name: Deploy
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+


### PR DESCRIPTION
Actions are now split into two

- Building and uploading which builds and uploads the website itself (Ran on commit and PR)
- Building and deploying which builds and deploys the website (requires the repo to use github actions for deploy instead of a branch (Ran manually)

This removes the need for gh-pages and a lot of hassle for no reason