### PR TITLE
[BUG-FIX] Collapse all autogenerated header-sidebars by default

### DIFF
--- a/markdown/.vuepress/config.js
+++ b/markdown/.vuepress/config.js
@@ -78,7 +78,7 @@ module.exports = {
   globalUIComponents: ["ThemeManager"],
 
   themeConfig: {
-    displayAllHeaders: true,
+    displayAllHeaders: false,
     lastUpdated: true,
     repo: "https://github.com/PojavLauncherTeam/PojavLauncherTeam.github.io/",
     docsDir: "",


### PR DESCRIPTION
Old config.js relied on some undefined behavior that did this for some reason by default, now we have to specify it.