### PR TITLE
Fix the FAQ link

### DIFF
--- a/markdown/wiki/index.md
+++ b/markdown/wiki/index.md
@@ -2,6 +2,6 @@
 # Welcome to the PojavLauncher Wiki!
 ____
 * Get started by [installing Pojavlauncher](./getting_started/INSTALL)!
-* Got a question? Check out our [FAQ](./faq/RPWORLDNOTSHOWINGUP)!
+* Got a question? Check out our [FAQ](./faq/INSTALLATIONOFMODSRPWORLDS)!
 * Wanna contribute to the project? [Look here](../contribute/CONT-WEBSITE.md)
 


### PR DESCRIPTION
I noticed the FAQ link was broken and leads to a 404 error page